### PR TITLE
Add support for custom config paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function Configstore(id, defaults, opts) {
 
 	// if id is an absolute path we treat id as the full config path,
 	// otherwise we save config to the default location
-	this.path = path.dirname(id) !== '.' ? id : path.join(configDir, pathPrefix);
+	this.path = path.dirname(id) === '.' ? path.join(configDir, pathPrefix) : id;
 
 	this.all = assign({}, defaults || {}, this.all || {});
 }

--- a/index.js
+++ b/index.js
@@ -22,7 +22,9 @@ function Configstore(id, defaults, opts) {
 		path.join(id, 'config.json') :
 		path.join('configstore', id + '.json');
 
-	this.path = path.join(configDir, pathPrefix);
+	// if id is an absolute path we treat id as the full config path,
+	// otherwise we save config to the default location
+	this.path = path.dirname(id) !== '.' ? id : path.join(configDir, pathPrefix);
 
 	this.all = assign({}, defaults || {}, this.all || {});
 }

--- a/readme.md
+++ b/readme.md
@@ -33,15 +33,20 @@ console.log(conf.get('awesome'));
 
 ## API
 
-### Configstore(packageName, [defaults], [options])
+### Configstore(idOrPath, [defaults], [options])
 
 Create a new Configstore instance `config`.
 
-#### packageName
+#### idOrPath
 
 Type: `string`
 
-Name of your package.
+Name of your package or some other unique ID. It can also be an absolute path to
+the config file (e.g. `/foo/bar/config.json` or `c:\foo\bar\config.json`).
+Passing a path is useful if your app has a designated place to store user data
+(e.g. if you are using [Electron](http://electron.atom.io/), you can store the
+config under the [`userData`](https://github.com/atom/electron/blob/master/docs/api/app.md#appgetpathname)
+directory).
 
 #### defaults
 
@@ -58,7 +63,12 @@ Type: `object`
 Type: `boolean`  
 Default: `false`
 
-Store the config at `$CONFIG/package-name/config.json` instead of the default `$CONFIG/configstore/package-name.json`. This is not recommended as you might end up conflicting with other tools, rendering the "without having to think" idea moot.
+Store the config at `$CONFIG/package-name/config.json` instead of the default
+`$CONFIG/configstore/package-name.json`. This is not recommended as you might
+end up conflicting with other tools, rendering the "without having to think"
+idea moot.
+
+##### path
 
 ### config.set(key, value)
 
@@ -92,8 +102,8 @@ Get the item count.
 
 ### config.path
 
-Get the path to the config file. Can be used to show the user where the config file is located or even better open it for them.
-
+Get the path to the config file. Can be used to show the user where the config
+file is located or even better open it for them.
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@
 'use strict';
 var assert = require('assert');
 var fs = require('fs');
+var path = require('path');
 var pathExists = require('path-exists');
 var Configstore = require('./');
 var configstorePath = new Configstore('configstore-test').path;
@@ -51,8 +52,28 @@ it('should use default value', function () {
 
 it('support global namespace path option', function () {
 	var conf = new Configstore('configstore-test', {}, {globalConfigPath: true});
-	var regex = /configstore-test\/config.json$/;
+	var regex = /configstore-test(\/|\\)config.json$/;
 	assert(regex.test(conf.path));
+});
+
+it('support custom path', function () {
+	var configPath = path.join(__dirname, 'configstore-custom.json');
+	var deleteConfig = function () {
+		try {
+			fs.unlinkSync(configPath);
+		} catch (e) {
+			// Don't care
+		}
+	};
+
+	// Remove possible residues from previous runs
+	deleteConfig();
+
+	var conf = new Configstore(configPath);
+	conf.set('foo', 'bar');
+	var exists = pathExists.sync(configPath);
+	deleteConfig();
+	assert(exists);
 });
 
 it('make sure `.all` is always an object', function () {


### PR DESCRIPTION
Useful when your app has a designated place to store user data (e.g. Electron's userData directory).
