### PR TITLE
Add support for using a custom error handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,10 @@ var permissionError = 'You don\'t have access to this file.';
 var defaultPathMode = parseInt('0700', 8);
 var writeFileOptions = {mode: parseInt('0600', 8)};
 
+function throwError(err) {
+	throw err;
+}
+
 function Configstore(id, defaults, opts) {
 	opts = opts || {};
 
@@ -25,6 +29,8 @@ function Configstore(id, defaults, opts) {
 	// if id is an absolute path we treat id as the full config path,
 	// otherwise we save config to the default location
 	this.path = path.dirname(id) === '.' ? path.join(configDir, pathPrefix) : id;
+
+	this.onError = opts.onError || throwError;
 
 	this.all = assign({}, defaults || {}, this.all || {});
 }
@@ -52,7 +58,8 @@ Configstore.prototype = Object.create(Object.prototype, {
 					return {};
 				}
 
-				throw err;
+				this.onError(err, this);
+				return {};
 			}
 		},
 		set: function (val) {
@@ -68,7 +75,7 @@ Configstore.prototype = Object.create(Object.prototype, {
 					err.message = err.message + '\n' + permissionError + '\n';
 				}
 
-				throw err;
+				this.onError(err, this);
 			}
 		}
 	},

--- a/readme.md
+++ b/readme.md
@@ -12,8 +12,8 @@ Example: `~/.config/configstore/some-id.json`
 const Configstore = require('configstore');
 const pkg = require('./package.json');
 
-// Init a Configstore instance with an unique ID e.g.
-// package name and optionally some default values
+// Init a Configstore instance with an unique ID (e.g. package name) and
+// optionally some default values
 const conf = new Configstore(pkg.name, {foo: 'bar'});
 
 conf.set('awesome', true);
@@ -68,7 +68,16 @@ Store the config at `$CONFIG/package-name/config.json` instead of the default
 end up conflicting with other tools, rendering the "without having to think"
 idea moot.
 
-##### path
+##### onError
+
+Type: `function`
+Default: The default handler throws on error
+
+When a read/write error occurs we pass it to the onError handler. The handler's
+signature is `(err, conf)`, where err is an `Error` and conf is the
+current config instance. Use a custom onError handler if you don't want to throw
+on errors (e.g. you are working with non-essential data) or if you want to
+implement some custom handling (e.g. send errors to server).
 
 ### config.set(key, value)
 


### PR DESCRIPTION
The default behavior is to throw when ever we fail to read or write the config. This is fine for most cases, but some might want to customize that. For example you can send an error log to your server instead of
throwing. Or maybe you are storing non-essential data so you just don't want to throw.
This PR adds a new option called `onError` which you can use to pass your own handler (see the readme for details).
